### PR TITLE
Fixed tutorials 2 and 3

### DIFF
--- a/tutorials/tutorial_02.cpp
+++ b/tutorials/tutorial_02.cpp
@@ -57,15 +57,17 @@ int main(int argc, char **argv)
     // Declare the computations c_blurx and c_blury.
     computation c_input("[N]->{c_input[i,j]: 0<=i<N and 0<=j<N}", expr(), false, p_uint8, &blurxy);
 
-    expr e1 = (c_input(var("i") - 1, var("j")) +
-               c_input(var("i")    , var("j")) +
-               c_input(var("i") + 1, var("j"))) / ((uint8_t) 3);
+    var i("i"), j("j");
+
+    expr e1 = (c_input(i - 1, j) +
+               c_input(i    , j) +
+               c_input(i + 1, j)) / ((uint8_t) 3);
 
     computation c_blurx("[N,M]->{c_blurx[i,j]: 0<i<N and 0<j<M}", e1, true, p_uint8, &blurxy);
 
-    expr e2 = (c_blurx(var("i"), var("j") - 1) +
-               c_blurx(var("i"), var("j")) +
-               c_blurx(var("i"), var("j") + 1)) / ((uint8_t) 3);
+    expr e2 = (c_blurx(i, j - 1) +
+               c_blurx(i, j) +
+               c_blurx(i, j + 1)) / ((uint8_t) 3);
 
     computation c_blury("[N,M]->{c_blury[i,j]: 1<i<N-1 and 1<j<M-1}", e2, true, p_uint8, &blurxy);
 

--- a/tutorials/wrapper_tutorial_03.cpp
+++ b/tutorials/wrapper_tutorial_03.cpp
@@ -21,6 +21,8 @@ int main(int, char **)
 
     // Reference matrix multiplication
     Halide::Buffer<uint8_t> C2_buf(NN, NN);
+    init_buffer(C2_buf, (uint8_t)0);
+
     for (int i = 0; i < NN; i++)
         for (int j = 0; j < NN; j++)
             for (int k = 0; k < NN; k++)


### PR DESCRIPTION
For tutorial 2, removed the confusing var("i") and var("j") redundancy.
For tutorial 3 wrapper, added initialization for C2_buf to 0 so that
tests pass.